### PR TITLE
import-export info modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
 # V2 Rewrite
 
 Some sort of a TODO:
-- [x] migrate from npm to pnpm
-- [x] migrate from rollup to vite
-- [x] ~~HMR~~
-- [x] rewrite and create components with ts and vue/svelte
-- [x] try redesigning the artifact dataset structure
-- [x] "host" the dataset on github instead of bundling with the extension
-- [x] improve content script's mounting
-- [x] listen for new character panels ~~as well as detect when they are removed~~
-- [x] consider wxt/storage's versioning for dataset fetching
-- [x] ~~tests for Svelte components?~~
-- [x] go through the answers to the Feedback form and check for any suggestions for new features
-- [x] rewrite the README
-- [ ] ensure Firefox compatibility?
-  - this was not nearly as easy and straightforward as I thought it would be, or frankly, should be
-  - [ ] publish on Firefox and find testers -> collect feedback
-- [x] publish on Chrome Web Store
-- [ ] use a library to validate the editor data; especially the set's name
+- [ ] use a library to validate the editor data; especially the set's name?
   - [ArkType](https://arktype.io/) seems pretty fast
-- [ ] internationalization / i18n
+- [ ] translations
   - perhaps store a ID for sets in the dataset, and have localizations bundled with the extension
+  - default language to same as 1) browser's 2) Genshin Center's 3) user choice
 - [ ] notification system for updates
-- [x] try using a temporary automounting UI to wait for the panels, loop through them, mount a separate UI for each, and then unmount the main UI
-  - this can replace a half of the current mutation observer, leaving it in charge of new panels rather than all of them
+  - similar to dataset, read changelog or such from GitHub repo
+- [] locked main stat for flower and plume
+- [] drop down menu for (main) stats
+  - allow custom too
+- [ ] port to Firefox and publish
 
 ## New features / suggestions in consideration
-- drop down menu for stats
 - field for notes, shared between all artifacts, and displayed below the artifacts?
 - field for artifact level?
-- locked main stat for flower and plume
-- better explanation for import / export
 
 [![Chrome Web Store Users](https://img.shields.io/chrome-web-store/users/jleonalkkhbfeafkmfgofopiadjkalno?style=for-the-badge&logo=googlechrome&label=Chrome%20Users&color=orange)](https://chrome.google.com/webstore/detail/artifacts-for-genshin-cen/jleonalkkhbfeafkmfgofopiadjkalno)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Some sort of a TODO:
 - [ ] ensure Firefox compatibility?
   - this was not nearly as easy and straightforward as I thought it would be, or frankly, should be
   - [ ] publish on Firefox and find testers -> collect feedback
-- [ ] publish on Chrome Web Store
+- [x] publish on Chrome Web Store
 - [ ] use a library to validate the editor data; especially the set's name
   - [ArkType](https://arktype.io/) seems pretty fast
 - [ ] internationalization / i18n
@@ -26,10 +26,6 @@ Some sort of a TODO:
   - this can replace a half of the current mutation observer, leaving it in charge of new panels rather than all of them
 
 ## New features / suggestions in consideration
-- smaller artifacts slots & icons
-  - currently they are a bit larger than the planner's native material icons
-- use the [same checkmark](https://genshin-center.com/images/general/check.png) as the planner
-- less opacity when disabled, similar to the materials
 - drop down menu for stats
 - field for notes, shared between all artifacts, and displayed below the artifacts?
 - field for artifact level?

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Some sort of a TODO:
   - default language to same as 1) browser's 2) Genshin Center's 3) user choice
 - [ ] notification system for updates
   - similar to dataset, read changelog or such from GitHub repo
-- [] locked main stat for flower and plume
-- [] drop down menu for (main) stats
+- [ ] locked main stat for flower and plume
+- [ ] drop down menu for (main) stats
   - allow custom too
 - [ ] port to Firefox and publish
 

--- a/src/components/ExtensionSettings.svelte
+++ b/src/components/ExtensionSettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ExportModal from "./modals/ExportModal.svelte";
+    import ImportExportInfoModal from "./modals/ImportExportInfoModal.svelte";
     import { exportArtifactData, importArtifactData } from "@/lib/dataManager";
     import { modals } from "./modals/Modals.svelte";
 
@@ -28,16 +29,40 @@
         const data = exportArtifactData();
         modals.open(ExportModal, { data });
     };
+
+    const openInfoModal = () => {
+        // modal for displaying detailed info about import / export
+        modals.open(ImportExportInfoModal);
+    };
 </script>
 
 <div class="PlannerOptions_section__y90n3">
     <div class="Radio_radio__t_pCN">
-        <div class="Radio_radioLabel__FlU7k">Import & Export Artifact Data</div>
+        <div class="Radio_radioLabel__FlU7k">
+            <div class="PlannerOptions_titleWrapper__pAkcp">
+                <h3>Import & Export Artifact Data</h3>
+                <button
+                    onclick={openInfoModal}
+                    class="PlannerOptions_info__h9H24"
+                    aria-label="Info on Import & Export"
+                >
+                    <div class="PlannerOptions_infoImg__VQwIY"></div>
+                </button>
+            </div>
+        </div>
         <div class="import_export_wrapper" style="max-width: 440px;">
-            <button onclick={importData} class="" title="Import Data">
+            <button
+                class="import-export"
+                onclick={importData}
+                title="Import Data"
+            >
                 Import Data
             </button>
-            <button onclick={exportData} title="Export Data">
+            <button
+                class="import-export"
+                onclick={exportData}
+                title="Export Data"
+            >
                 Export Data
             </button>
         </div>
@@ -51,7 +76,7 @@
         width: 100%;
     }
 
-    button {
+    button.import-export {
         background-color: #ece5d8;
         color: #000;
         border-radius: 5px;

--- a/src/components/artifacts/ArtifactSlot.svelte
+++ b/src/components/artifacts/ArtifactSlot.svelte
@@ -90,6 +90,10 @@
         cursor: pointer;
     }
 
+    button.check {
+        opacity: 0.4; /* follow similar styling with completed materials */
+    }
+
     .flowerSlot {
         background-image: url("https://i.imgur.com/GqSEgvB.png");
     }

--- a/src/components/modals/ImportExportInfoModal.svelte
+++ b/src/components/modals/ImportExportInfoModal.svelte
@@ -13,8 +13,8 @@
     <div class="PlannerOptions_infoBox__41So_">
         <h3>Export</h3>
         <p>
-            Export extension's save data. The data can then be saved to file and
-            saved between users or computers, for example.
+            Export extension's save data. The data can then be saved to a file
+            and moved between users or devices.
         </p>
         <h3>Import</h3>
         <p>
@@ -23,6 +23,9 @@
                 >This does NOT support GOOD format or others!</span
             >
         </p>
+    </div>
+    <div class="buttonWrapper">
+        <button onclick={() => close()}>OK</button>
     </div>
 </ModalBase>
 
@@ -42,5 +45,21 @@
         font-weight: 800;
         flex-grow: 1;
         text-align: center;
+    }
+
+    .buttonWrapper {
+        /* Schedule_buttonsWrapper__fdOV_ */
+        display: flex;
+        justify-content: space-around;
+        padding: 10px;
+    }
+
+    .buttonWrapper button {
+        padding: 10px 40px;
+        color: #000;
+        background: #ece5d8;
+        border-radius: 20px;
+        transition: 0.2s;
+        cursor: pointer;
     }
 </style>

--- a/src/components/modals/ImportExportInfoModal.svelte
+++ b/src/components/modals/ImportExportInfoModal.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+    import type { ModalProps } from "@/lib/modals/Modal.svelte";
+    import ModalBase from "./ModalBase.svelte";
+    interface Props extends ModalProps {}
+    let { isOpen, close }: Props = $props();
+</script>
+
+<ModalBase {isOpen}>
+    <!-- <div>{data}</div> -->
+    <div class="modalHeader">
+        <h3>Import / Export</h3>
+    </div>
+    <div class="PlannerOptions_infoBox__41So_">
+        <h3>Export</h3>
+        <p>
+            Export extension's save data. The data can then be saved to file and
+            saved between users or computers, for example.
+        </p>
+        <h3>Import</h3>
+        <p>
+            Import previously exported extension save data.<br />
+            <span style="color: red;"
+                >This does NOT support GOOD format or others!</span
+            >
+        </p>
+    </div>
+</ModalBase>
+
+<style>
+    .modalHeader {
+        /* Schedule_taskTopBar__lV1W8 */
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px;
+        flex-direction: column;
+    }
+
+    .modalHeader > h3 {
+        font-size: 26px;
+        line-height: 54px;
+        font-weight: 800;
+        flex-grow: 1;
+        text-align: center;
+    }
+</style>


### PR DESCRIPTION
Added an info button next to the Import & Export settings to provide more information.

There has been some confusion when users have tried to import artifact data using the GOOD-format which is not nor will be supported whatsoever by the extension.