### PR TITLE
main stat defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Some sort of a TODO:
   - default language to same as 1) browser's 2) Genshin Center's 3) user choice
 - [ ] notification system for updates
   - similar to dataset, read changelog or such from GitHub repo
-- [ ] drop down menu for (main) stats
-  - allow custom too
 - [ ] port to Firefox and publish
 
 ## New features / suggestions in consideration

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Some sort of a TODO:
   - default language to same as 1) browser's 2) Genshin Center's 3) user choice
 - [ ] notification system for updates
   - similar to dataset, read changelog or such from GitHub repo
-- [ ] locked main stat for flower and plume
 - [ ] drop down menu for (main) stats
   - allow custom too
 - [ ] port to Firefox and publish

--- a/src/components/modals/EditorModal.svelte
+++ b/src/components/modals/EditorModal.svelte
@@ -66,12 +66,15 @@
             name="artifactSet"
             bind:artifact
         />
+        <!-- disable dropdown for flower and plume -->
         <EditorInput
             sectionName={"Main Stat"}
             placeholder={"Enter main stat..."}
             name="mainStat"
             bind:artifact
-            listAttribute="mainStatOptions"
+            listAttribute={type === "flower" || type === "plume"
+                ? ""
+                : "mainStatOptions"}
         />
         <EditorInput
             sectionName={"Sub Stat"}

--- a/src/components/modals/EditorModal.svelte
+++ b/src/components/modals/EditorModal.svelte
@@ -71,6 +71,7 @@
             placeholder={"Enter main stat..."}
             name="mainStat"
             bind:artifact
+            listAttribute="mainStatOptions"
         />
         <EditorInput
             sectionName={"Sub Stat"}

--- a/src/components/modals/EditorModal.svelte
+++ b/src/components/modals/EditorModal.svelte
@@ -15,10 +15,21 @@
     }
     let { isOpen, close, character, type }: Props = $props();
 
+    const getMainStatDefaultValue = (type: ArtifactSlotType): string => {
+        /* flower/plume always has HP/ATK as the main stat. */
+        if (type === "flower") {
+            return "HP";
+        }
+        if (type === "plume") {
+            return "ATK";
+        }
+        return "";
+    };
+
     let initialState: ArtifactData = {
         check: false,
         artifactSet: "",
-        mainStat: "",
+        mainStat: getMainStatDefaultValue(type),
         subStats: "",
     };
     // if character has data for the artifact, use it. Otherwise use the initial empty state

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,3 +21,18 @@ export const CHECKMARK_VALUES = {
 
 export const DATASET_URL =
   "https://raw.githubusercontent.com/kripi-png/ArtifactsForGenshinCenter/main/src/dataset.json";
+
+export const MAIN_STAT_OPTIONS = [
+  "HP",
+  "HP%",
+  "ATK",
+  "ATK%",
+  "DEF%",
+  "Elemental Mastery",
+  "Elemental Recharge",
+  "Physical DMG %",
+  "Elemental DMG % <element>",
+  "CRIT Rate %",
+  "CRIT DMG %",
+  "Healing Bonus %",
+];

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -1,6 +1,7 @@
 import {
   generateArtifactDatalist,
   generateCharacterObserver,
+  generateMainStatDatalist,
   isPanelWeapon,
   mountSlots,
 } from "@/lib/artifactManager";
@@ -77,6 +78,7 @@ export default defineContentScript({
     }).autoMount();
 
     generateArtifactDatalist();
+    generateMainStatDatalist();
   },
 });
 

--- a/src/lib/artifactManager.ts
+++ b/src/lib/artifactManager.ts
@@ -3,6 +3,7 @@ import type { ContentScriptContext } from "wxt/client";
 import ArtifactDisableButton from "../components/artifacts/ArtifactDisableButton.svelte";
 import ArtifactSlotWrapper from "../components/artifacts/ArtifactSlotWrapper.svelte";
 import { getAllArtifactSets } from "./dataManager";
+import { MAIN_STAT_OPTIONS } from "@/constants";
 
 export const generateArtifactDatalist = async () => {
   /* pre-generate the datalist for the editor dropdown */
@@ -13,6 +14,24 @@ export const generateArtifactDatalist = async () => {
   artifactSets.forEach((setName: string) => {
     const option = document.createElement("option");
     option.value = setName;
+    datalist.appendChild(option);
+  });
+
+  document.body.appendChild(datalist);
+};
+
+export const generateMainStatDatalist = async () => {
+  /*
+  pre-generate the datalist for the main stat input of the artifact editor.
+  The possible options are defined in src/constants.ts
+  */
+
+  const datalist = document.createElement("datalist");
+  datalist.id = "mainStatOptions";
+
+  MAIN_STAT_OPTIONS.forEach((value: string) => {
+    const option = document.createElement("option");
+    option.value = value;
     datalist.appendChild(option);
   });
 


### PR DESCRIPTION
Changes
- artifact's main stat now defaults to HP and ATK for flower and plume respectively
- the other 3 artifact types have a drop down for easier stat selection
- all stats can be overwritten (even plume and flower) 